### PR TITLE
Make stdin and stdout optional

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -14,21 +14,25 @@ func executor(workdir string, inputFifoPath string, outputFifoPath string, error
 
 	logger.Printf("Command path: %v\n", proc.Path)
 
-	stdinFifo := openReadCloser(inputFifoPath)
-	stdoutFifo := openWriteCloser(outputFifoPath)
-	stderrFifo := openWriteCloser(errorFifoPath)
+	signal := make(chan struct{})
 
-	signal := make(chan bool)
-	go startPipeline(proc, stdinFifo, stdoutFifo, stderrFifo, signal)
+	stdinFifo := openReadCloser(inputFifoPath, signal)
+	stdoutFifo := openWriteCloser(outputFifoPath, signal)
+	stderrFifo := openWriteCloser(errorFifoPath, signal)
 
-	// wait pipeline to start
-	<-signal
+	outputStreamerExit, commandExit := startPipeline(proc, stdinFifo, stdoutFifo, stderrFifo)
 
 	err := proc.Start()
 	fatalIf(err)
 
-	// wait for pipeline exit
-	<-signal
+	// wait for pipline to exit
+	select {
+	case <-outputStreamerExit:
+	case <-commandExit:
+	}
+
+	// signal that command is completed
+	close(signal)
 
 	err = safeExit(proc)
 	if e, ok := err.(*exec.Error); ok {
@@ -42,7 +46,7 @@ func executor(workdir string, inputFifoPath string, outputFifoPath string, error
 	return err
 }
 
-func startPipeline(proc *exec.Cmd, stdinFifo io.ReadCloser, stdoutFifo io.WriteCloser, stderrFifo io.WriteCloser, signal chan bool) {
+func startPipeline(proc *exec.Cmd, stdinFifo io.ReadCloser, stdoutFifo io.WriteCloser, stderrFifo io.WriteCloser) (<-chan struct{}, <-chan struct{}) {
 	// some commands expect stdin to be connected
 	cmdInput, err := proc.StdinPipe()
 	fatalIf(err)
@@ -60,17 +64,7 @@ func startPipeline(proc *exec.Cmd, stdinFifo io.ReadCloser, stdoutFifo io.WriteC
 	startErrorStreamer(cmdError, stderrFifo)
 	commandExit := createCommandExitChan(os.Stdin)
 
-	// signal that pipline is setup
-	signal <- true
-
-	// wait for pipline to exit
-	select {
-	case <-outputStreamerExit:
-	case <-commandExit:
-	}
-
-	// signal pipeline shutdown
-	signal <- true
+	return outputStreamerExit, commandExit
 }
 
 func safeExit(proc *exec.Cmd) error {
@@ -90,19 +84,30 @@ func safeExit(proc *exec.Cmd) error {
 	}
 }
 
-func openReadCloser(fifoPath string) io.ReadCloser {
-	return openFile(fifoPath, os.O_RDONLY)
-}
-
-func openWriteCloser(fifoPath string) io.WriteCloser {
-	var file io.WriteCloser
+func openReadCloser(fifoPath string, signal <-chan struct{}) io.ReadCloser {
 	switch fifoPath {
 	case "":
-		file = new(nullWriteCloser)
+		writer := NullReadWriteCloser{
+			Signal: make(chan struct{}),
+		}
+		linkChannel(writer, signal)
+		return writer
 	default:
-		file = openFile(fifoPath, os.O_WRONLY)
+		return openFile(fifoPath, os.O_RDONLY)
 	}
-	return file
+}
+
+func openWriteCloser(fifoPath string, signal <-chan struct{}) io.WriteCloser {
+	switch fifoPath {
+	case "":
+		reader := NullReadWriteCloser{
+			Signal: make(chan struct{}),
+		}
+		linkChannel(reader, signal)
+		return reader
+	default:
+		return openFile(fifoPath, os.O_WRONLY)
+	}
 }
 
 func openFile(path string, mode int) *os.File {
@@ -123,4 +128,11 @@ func createCommandExitChan(stdin io.ReadCloser) <-chan struct{} {
 	}()
 
 	return exitSignal
+}
+
+func linkChannel(closer io.Closer, b <-chan struct{}) {
+	go func(){
+		<-b
+		closer.Close()
+	}()
 }

--- a/logger.go
+++ b/logger.go
@@ -12,7 +12,9 @@ func initLogger(flag string) {
 	var file io.Writer
 	switch flag {
 	case "":
-		file = new(nullWriteCloser)
+		file = NullReadWriteCloser{
+			Signal: make(chan struct{}, 1),
+		}
 	case "|1":
 		file = os.Stdout
 	case "|2":

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ const usage = "Usage: odu [options] -- <program> [<arg>...]"
 
 var dirFlag = flag.String("dir", ".", "working directory for the spawned process")
 var logFlag = flag.String("log", "", "enable logging")
-var stdinFlag = flag.String("stdin", "", "path to fifo file from which input is read")
-var stdoutFlag = flag.String("stdout", "", "path to fifo file to which output written")
+var stdinFlag = flag.String("stdin", "", "path to fifo file from which input is read. ignored if not set")
+var stdoutFlag = flag.String("stdout", "", "path to fifo file to which output written. ignored if not set")
 var stderrFlag = flag.String("stderr", "", "path to fifo file to which stderr output is written. stderr is ignored if its not set (default)")
 var versionFlag = flag.Bool("v", false, "print version and exit")
 
@@ -28,11 +28,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if notFifo(*stdoutFlag) {
+	if *stdoutFlag != "" && notFifo(*stdoutFlag) {
 		dieUsage("stdin param is not a fifo file")
 	}
 
-	if notFifo(*stdinFlag) {
+	if *stdinFlag != "" && notFifo(*stdinFlag) {
 		dieUsage("stdout param is not a fifo file")
 	}
 


### PR DESCRIPTION
This is useful when we know that command does not take any inout/output. For example commands such as `find`, `ls`